### PR TITLE
Added the game state to the save and restore instance state functions

### DIFF
--- a/app/src/main/java/com/cop4655/luis/project2/MainActivity.java
+++ b/app/src/main/java/com/cop4655/luis/project2/MainActivity.java
@@ -235,6 +235,9 @@ public class MainActivity extends AppCompatActivity {
 
         //save currentPlayer
         outState.putString("cp", getCurrentPlayer());
+
+        //save game status
+        outState.putBoolean("over", gameOver);
     }
 
     @Override
@@ -260,6 +263,11 @@ public class MainActivity extends AppCompatActivity {
 
         //get currentPlayer
         setCurrentPlayer(savedInstanceState.getString("cp"));
+
+        //get game status
+        if (savedInstanceState.getBoolean("over")){
+            lockBoard();
+        }
     }
 
     private class gameBoardListener implements View.OnClickListener {


### PR DESCRIPTION
On orientation switch, the game was saving the button text.  Then if the button had a symbol on it already, making them unclickable.  However, the game should lock all button when the game is over.  When it switched, it was locking down empty buttons since it was not checking the game state, just if a button had a symbol or not.